### PR TITLE
Fix major renaming conflicts, add depth renaming flag and change function name

### DIFF
--- a/python/_rename.py
+++ b/python/_rename.py
@@ -46,7 +46,7 @@ def make_upper_camel_kebab(x):
     return "-".join(title_words)
 
 
-def handle_exceptions(old_name, new_name):
+def try_rename(old_name, new_name):
     # handle FileExistsError
     if os.path.exists(new_name) and old_name != new_name:
         print(f"Can't rename {old_name} to {new_name}.")
@@ -81,7 +81,7 @@ def upper_camel_kebab(cwd):
         new_dirpath = "\\".join(dir_in_list2)
 
         # for renaming and exception handling
-        handle_exceptions(dirpath, new_dirpath)
+        try_rename(dirpath, new_dirpath)
 
     # Rename files
     for dirpath, _, filenames in os.walk(cwd):
@@ -107,7 +107,7 @@ def upper_camel_kebab(cwd):
                 new_filepath = "\\".join(filepath_in_list2)
 
                 # for renaming and handling exceptions
-                handle_exceptions(filepath, new_filepath)
+                try_rename(filepath, new_filepath)
 
 
 def kebab(cwd):
@@ -128,7 +128,7 @@ def kebab(cwd):
         new_dirpath = cwd + child.replace(" ", "-")
 
         # for renaming and exception handling
-        handle_exceptions(dirpath, new_dirpath)
+        try_rename(dirpath, new_dirpath)
 
     # Rename files
     for dirpath, _, filenames in os.walk(cwd):
@@ -153,7 +153,7 @@ def kebab(cwd):
                 new_filepath.replace("\\", "/")
 
                 # for renaming and exception handling
-                handle_exceptions(filepath, new_filepath)
+                try_rename(filepath, new_filepath)
 
 
 parser = argparse.ArgumentParser(

--- a/python/_rename.py
+++ b/python/_rename.py
@@ -13,7 +13,7 @@
     Place this script in the directory whose sub-folders, files and sub-files you want to rename.
     Change the working directory in command line to this directory and run the python command;
 
-    Some examples, 
+    Some examples,
 
     Command: python _rename.py --kebab
     Renames the files and the folders:
@@ -40,10 +40,21 @@ extensions = (".pdf", ".doc", ".docx", ".xls", ".xlsx",
 
 
 def make_upper_camel_kebab(x):
-    # convert test folder to Test-Folder
-    strings = x.split()
-    title_words = [a[0].upper() + a[1:] for a in strings]
-    return "-".join(title_words)
+    # convert
+    # \\python programming\\hello world\\hello world.txt to
+    # \\Python-Programming\\Hello-World\\Hello-World.txt
+    dir_in_list = x.split("\\")
+    titled_path = ""
+    for s in dir_in_list:
+        if " " in s:
+            strings = s.split()
+            titled_words = [a.capitalize() for a in strings]
+            titled_path += "\\" + "-".join(titled_words)
+        else:
+            titled_path += "\\" + s
+
+    # rstrip is for handling error renaming the working directory
+    return titled_path.rstrip("\\")
 
 
 def try_rename(old_name, new_name):
@@ -74,10 +85,9 @@ def upper_camel_kebab(cwd):
             last_index = child.rfind("\\")  # index of the last backslash
             part1 = child[:last_index]
             part2 = child[last_index:]
-            dirpath = cwd + make_upper_camel_kebab(part1) + part2
+            dirpath = cwd + make_upper_camel_kebab(part1[1:]) + part2
 
-        # replace the dir path blank spaces with hyphen
-        new_dirpath = cwd + make_upper_camel_kebab(child)
+        new_dirpath = cwd + make_upper_camel_kebab(child[1:])
 
         # for renaming and exception handling
         try_rename(dirpath, new_dirpath)
@@ -97,11 +107,11 @@ def upper_camel_kebab(cwd):
                     last_index = child.rfind("\\")
                     part1 = child[:last_index]
                     part2 = child[last_index:]
-                    filepath = cwd + make_upper_camel_kebab(part1) + part2
+                    filepath = cwd + make_upper_camel_kebab(part1[1:]) + part2
 
-                # replace the dir path blank spaces with hyphen
-                new_filepath = cwd + make_upper_camel_kebab(child)
+                new_filepath = cwd + make_upper_camel_kebab(child[1:])
 
+                # for handling escape character in path
                 new_filepath.replace("\\", "/")
 
                 # for renaming and exception handling
@@ -122,7 +132,6 @@ def kebab(cwd):
             part2 = child[last_index:]
             dirpath = cwd + part1.replace(" ", "-") + part2
 
-        # replace the dir path blank spaces with hyphen
         new_dirpath = cwd + child.replace(" ", "-")
 
         # for renaming and exception handling
@@ -145,9 +154,9 @@ def kebab(cwd):
                     part2 = child[last_index:]
                     filepath = cwd + part1.replace(" ", "-") + part2
 
-                # replace the dir path blank spaces with hyphen
                 new_filepath = cwd + child.replace(" ", "-")
 
+                # for handling escape character in path
                 new_filepath.replace("\\", "/")
 
                 # for renaming and exception handling

--- a/python/_rename.py
+++ b/python/_rename.py
@@ -52,7 +52,7 @@ def handle_exceptions(old_name, new_name):
         print(f"Can't rename {old_name} to {new_name}.")
         print(f"{new_name} already exists.\n")
         return
-        
+
     try:
         os.rename(old_name, new_name)
     except PermissionError:
@@ -112,9 +112,20 @@ def upper_camel_kebab(cwd):
 
 def kebab(cwd):
     # Rename folders
-    for dirpath, _, filenames in os.walk(cwd):
+    dirpaths = [x[0] for x in os.walk(cwd)]
+
+    for dirpath in dirpaths:
+        # prevent renaming the parent directory
+        child = dirpath.replace(cwd, "")
+
+        if not os.path.exists(dirpath):
+            last_index = child.rfind("\\")  # index of the last backslash
+            part1 = child[:last_index]
+            part2 = child[last_index:]
+            dirpath = cwd + part1.replace(" ", "-") + part2
+
         # replace the dir path blank spaces with hyphen
-        new_dirpath = dirpath.replace(" ", "-")
+        new_dirpath = cwd + child.replace(" ", "-")
 
         # for renaming and exception handling
         handle_exceptions(dirpath, new_dirpath)
@@ -124,10 +135,24 @@ def kebab(cwd):
         for f in filenames:
             # check the file extension
             if f.endswith(extensions):
-                filepath = os.path.abspath(os.path.join(dirpath, f))
-                new_filepath = filepath.replace(" ", "-")
+                filepath = os.path.join(dirpath, f)
 
-                # for renaming and handling exceptions
+                # prevent renaming the parent directory
+                child = filepath.replace(cwd, "")
+
+                if not os.path.exists(filepath):
+                    # index of the last backslash
+                    last_index = child.rfind("\\")
+                    part1 = child[:last_index]
+                    part2 = child[last_index:]
+                    filepath = cwd + part1.replace(" ", "-") + part2
+
+                # replace the dir path blank spaces with hyphen
+                new_filepath = cwd + child.replace(" ", "-")
+
+                new_filepath.replace("\\", "/")
+
+                # for renaming and exception handling
                 handle_exceptions(filepath, new_filepath)
 
 

--- a/python/_rename.py
+++ b/python/_rename.py
@@ -64,21 +64,20 @@ def try_rename(old_name, new_name):
 
 def upper_camel_kebab(cwd):
     # Rename folders
-    for dirpath, _, filenames in os.walk(cwd):
-        # split the dirpath in "\"
-        dir_in_list = dirpath.split("\\")
+    dirpaths = [x[0] for x in os.walk(cwd)]
 
-        # capitalize the first letter after each space
-        # replace blank space with hyphen
-        dir_in_list2 = []
-        for s in dir_in_list:
-            if " " in s:
-                dir_in_list2.append(make_upper_camel_kebab(s))
-            else:
-                dir_in_list2.append(s)
+    for dirpath in dirpaths:
+        # prevent renaming the parent directory
+        child = dirpath.replace(cwd, "")
 
-        # join the list with "\" to get new dir name
-        new_dirpath = "\\".join(dir_in_list2)
+        if not os.path.exists(dirpath):
+            last_index = child.rfind("\\")  # index of the last backslash
+            part1 = child[:last_index]
+            part2 = child[last_index:]
+            dirpath = cwd + make_upper_camel_kebab(part1) + part2
+
+        # replace the dir path blank spaces with hyphen
+        new_dirpath = cwd + make_upper_camel_kebab(child)
 
         # for renaming and exception handling
         try_rename(dirpath, new_dirpath)
@@ -88,25 +87,24 @@ def upper_camel_kebab(cwd):
         for f in filenames:
             # check the file extension
             if f.endswith(extensions):
-                # full path of file
-                filepath = os.path.abspath(os.path.join(dirpath, f))
+                filepath = os.path.join(dirpath, f)
 
-                # split the filepath in "\"
-                filepath_in_list = filepath.split("\\")
+                # prevent renaming the parent directory
+                child = filepath.replace(cwd, "")
 
-                # capitalize the first letter after each space
-                # replace blank space with hyphen
-                filepath_in_list2 = []
-                for s in filepath_in_list:
-                    if " " in s:
-                        filepath_in_list2.append(make_upper_camel_kebab(s))
-                    else:
-                        filepath_in_list2.append(s)
+                if not os.path.exists(filepath):
+                    # index of the last backslash
+                    last_index = child.rfind("\\")
+                    part1 = child[:last_index]
+                    part2 = child[last_index:]
+                    filepath = cwd + make_upper_camel_kebab(part1) + part2
 
-                # join the list with "\" to get new dir name
-                new_filepath = "\\".join(filepath_in_list2)
+                # replace the dir path blank spaces with hyphen
+                new_filepath = cwd + make_upper_camel_kebab(child)
 
-                # for renaming and handling exceptions
+                new_filepath.replace("\\", "/")
+
+                # for renaming and exception handling
                 try_rename(filepath, new_filepath)
 
 


### PR DESCRIPTION
Fix in kebab renaming:
Fix 1.
Rename only the child directories and files, not the directories before the working directory.

Fix 2.
Support depth renaming.
Previously the script had to be run multiple times, to rename the child directories and files. Now, the script can support depth renaming.